### PR TITLE
Trigger whoami on window.load

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,14 +26,17 @@ const oAds = {
 	messageQueue: [],
 	init: () => {
 		initListeners();
+	}
+};
+
+
+function whoAmI() {
 		const detail = {
 			collapse: !!document.querySelector('[data-o-ads-collapse]'),
 			mastercompanion: !!document.querySelector('[data-o-ads-mc]')
 		};
 		sendMessage('oAds.whoami', detail);
-	}
 };
-
 /*
 * isValidSize
 * Checks the a requested resize dimensions are valid for this ad slot
@@ -141,6 +144,7 @@ function initListeners() {
 	window.addEventListener('oAds.collapse', eventHandler);
 	window.addEventListener('oAds.responsive', eventHandler);
 	window.addEventListener('oAds.resize', eventHandler);
+	window.addEventListener('load', whoAmI);
 }
 
 module.exports = oAds;

--- a/test/spec/identify.spec.js
+++ b/test/spec/identify.spec.js
@@ -23,6 +23,8 @@ describe('identifying the slot', () => {
 
 		window.top.addEventListener('message', listener);
 		oAds.init();
+		window.dispatchEvent(new Event('load'));
+
 	});
 
 	it('throws an error if the slot is not found', (done) => {
@@ -56,5 +58,6 @@ describe('identifying the slot', () => {
 
 		window.top.addEventListener('message', listener);
 		oAds.init();
+		window.dispatchEvent(new Event('load'));
 	});
 });

--- a/test/spec/queue.spec.js
+++ b/test/spec/queue.spec.js
@@ -30,6 +30,7 @@ describe('messages are queued when slot is not yet identified', () => {
 
 			window.top.addEventListener('message', listener);
 			oAds.init();
+			window.dispatchEvent(new Event('load'));
 		}, 0);
 	});
 });

--- a/test/spec/swipe.spec.js
+++ b/test/spec/swipe.spec.js
@@ -47,6 +47,7 @@ describe('passing swipe events to the parent window', () => {
 
 		oAds.init();
 		window.top.addEventListener('message', listener);
+		window.dispatchEvent(new Event('load'));
 	});
 
 	it('sends a message when the swipe moves', (done) => {
@@ -73,6 +74,7 @@ describe('passing swipe events to the parent window', () => {
 
 		oAds.init();
 		window.top.addEventListener('message', listener);
+		window.dispatchEvent(new Event('load'));
 	});
 
 	it('sends a message when the swipe ends', (done) => {
@@ -101,6 +103,7 @@ describe('passing swipe events to the parent window', () => {
 
 		oAds.init();
 		window.top.addEventListener('message', listener);
+		window.dispatchEvent(new Event('load'));
 	});
 
 	it('does not prevent default swipe handler if no configuration is sent across', (done) => {
@@ -128,6 +131,7 @@ describe('passing swipe events to the parent window', () => {
 
 		oAds.init();
 		window.top.addEventListener('message', listener);
+		window.dispatchEvent(new Event('load'));
 	});
 
 	it('prevents default swipe handler if configuration is sent across', (done) => {
@@ -155,6 +159,7 @@ describe('passing swipe events to the parent window', () => {
 
 		oAds.init();
 		window.top.addEventListener('message', listener);
+		window.dispatchEvent(new Event('load'));
 	});
 
 


### PR DESCRIPTION
@VladDubrovskis @andrewgeorgiou1981 @leggsimon 

The whoami event was being fired before the entire creative template was present, so the -collapse and -mc elements weren't there.

This defers the whoami event to fire on window.load (in the iframe)
