### PR TITLE
Add arbitrary message capability

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const oAdsEmbed = {
 		window.addEventListener('load', () => {
 			const messageEl = document.querySelector('[data-o-ads-message]');
 			if (messageEl) {
-				const message = messageEl.oAdsMessage;
+				const message = messageEl.dataset.oAdsMessage;
 				if (message) {
 					messenger.post({
 						type: 'oAdsEmbed.message',

--- a/main.js
+++ b/main.js
@@ -8,6 +8,17 @@ import messenger from './src/js/postMessenger';
 const oAdsEmbed = {
 	init: () => {
 		window.addEventListener('load', () => {
+			const messageEl = document.querySelector('[data-o-ads-message]');
+			if (messageEl) {
+				const message = messageEl.oAdsMessage;
+				if (message) {
+					messenger.post({
+						type: 'oAdsEmbed.message',
+						message: message
+					}, window.top);
+				}
+			}
+
 			const collapse = !!document.querySelector('[data-o-ads-collapse]');
 
 			messenger.post({ type: 'oAds.adIframeLoaded' });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/Financial-Times/o-ads-embed.git"
   },
   "scripts": {
-    "prepare": "npx snyk protect || npx snyk protect -d || true"
+    "prepare": "npx snyk protect || npx snyk protect -d || true",
+	"test-local": "karma start --browsers=Chrome --single-run=false -debug"
   },
   "husky": {
     "hooks": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -64,6 +64,58 @@ describe('o-ads-embed', () => {
 				window.dispatchEvent(new Event('load'));
 			});
 		});
+
+		context('message element exists on the page', () => {
+			it('should send a postMessage of type "oAdsEmbed.message"', (done) => {
+				fixtures.insertHtml('<script data-o-ads-message="sticko"></script>');
+				const postMessageSpy = sinon.spy(window.top, 'postMessage');
+				const expectedMessage = JSON.stringify(
+					{ 
+						type: 'oAdsEmbed.message',
+						message: 'sticky'
+					});
+
+				window.addEventListener('load', () => {
+					// Make sure the first event listener in main.js runs first
+					setTimeout(() => {
+						proclaim.equal(postMessageSpy.calledWith(expectedMessage, '*'), true);
+						postMessageSpy.restore();
+						done();
+					}, 0);
+				});
+
+				oAdsEmbed.init();
+				window.dispatchEvent(new Event('load'));
+			});
+
+			after(() => {
+				fixtures.reset();
+			});
+		});
+
+		context('collapse element exists on the page', () => {
+			it('should send a postMessage of type "oAds.collapse"', (done) => {
+				fixtures.insertHtml('<script data-o-ads-collapse></script>');
+				const postMessageSpy = sinon.spy(window.top, 'postMessage');
+				const expectedMessage = JSON.stringify({ type: 'oAds.collapse'});
+
+				window.addEventListener('load', () => {
+					// Make sure the first event listener in main.js runs first
+					setTimeout(() => {
+						proclaim.equal(postMessageSpy.calledWith(expectedMessage, '*'), true);
+						postMessageSpy.restore();
+						done();
+					}, 0);
+				});
+
+				oAdsEmbed.init();
+				window.dispatchEvent(new Event('load'));
+			});
+
+			after(() => {
+				fixtures.reset();
+			});
+		});
 	});
 
 	context('On touch event', () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -70,7 +70,7 @@ describe('o-ads-embed', () => {
 				fixtures.insertHtml('<script data-o-ads-message="sticky"></script>');
 				const postMessageSpy = sinon.spy(window.top, 'postMessage');
 				const expectedMessage = JSON.stringify(
-					{ 
+					{
 						type: 'oAdsEmbed.message',
 						message: 'sticky'
 					});

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -67,37 +67,13 @@ describe('o-ads-embed', () => {
 
 		context('message element exists on the page', () => {
 			it('should send a postMessage of type "oAdsEmbed.message"', (done) => {
-				fixtures.insertHtml('<script data-o-ads-message="sticko"></script>');
+				fixtures.insertHtml('<script data-o-ads-message="sticky"></script>');
 				const postMessageSpy = sinon.spy(window.top, 'postMessage');
 				const expectedMessage = JSON.stringify(
 					{ 
 						type: 'oAdsEmbed.message',
 						message: 'sticky'
 					});
-
-				window.addEventListener('load', () => {
-					// Make sure the first event listener in main.js runs first
-					setTimeout(() => {
-						proclaim.equal(postMessageSpy.calledWith(expectedMessage, '*'), true);
-						postMessageSpy.restore();
-						done();
-					}, 0);
-				});
-
-				oAdsEmbed.init();
-				window.dispatchEvent(new Event('load'));
-			});
-
-			after(() => {
-				fixtures.reset();
-			});
-		});
-
-		context('collapse element exists on the page', () => {
-			it('should send a postMessage of type "oAds.collapse"', (done) => {
-				fixtures.insertHtml('<script data-o-ads-collapse></script>');
-				const postMessageSpy = sinon.spy(window.top, 'postMessage');
-				const expectedMessage = JSON.stringify({ type: 'oAds.collapse'});
 
 				window.addEventListener('load', () => {
 					// Make sure the first event listener in main.js runs first


### PR DESCRIPTION
This adds the ability to send messages to the parent window with an arbitrary string with the value of the `o-ads-data-message` property if that property is present the creative wrapper.