### PR TITLE
install npm dependencies so that snyk can run during npm prepare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
+      - run: npm ci
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public


### PR DESCRIPTION
Fixes the current issue with publishing to npm from CircleCI -- https://circleci.com/gh/Financial-Times/o-ads-embed/112

![image](https://user-images.githubusercontent.com/1569131/65132611-23125980-d9f9-11e9-8d18-66c91bb5b41a.png)
