### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: npm config set prefix "$HOME/.local"
-      - run: npm i -g origami-build-tools@^7
+      - run: npm i -g origami-build-tools@^9
       - run: $HOME/.local/bin/obt install
       - run: $HOME/.local/bin/obt demo --demo-filter pa11y --suppress-errors
       - run: $HOME/.local/bin/obt verify

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,6 +1,5 @@
-/* global describe, context, it, after, beforeEach, afterEach */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
 import * as fixtures from './helpers/fixtures';
 import oAdsEmbed from '../main';
 import { dispatchTouchEvent } from './helpers/utils';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.