### PR TITLE
Added new postmessages to monitor smartmatch problems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 demos/local/
 reports/
 coverage/
-.editorconfig
 test-results.xml
 
 # Local config files #

--- a/main.js
+++ b/main.js
@@ -1,14 +1,14 @@
 import messenger from './src/js/postMessenger';
 
+const sendMonitoringEvent = message =>
+	messenger.post({ type: 'oAds.monitor', message }, window.top);
+
 const handleReceivedMessage = event => {
 	if (event.data && event.data.messageType === 'oAdsEmbed') {
 		if (event.origin === 'https://ft.com') {
 			window.oAdsEmbedData = event.data.body;
 		} else {
-			messenger.post({
-				type: 'oAds.monitor',
-				message: `oAdsEmbed message from unexpected origin: ${event.origin}`
-			}, window.top);
+			sendMonitoringEvent(`oAdsEmbed message from unexpected origin: ${event.origin}`);
 		}
 	}
 };
@@ -16,16 +16,17 @@ const handleReceivedMessage = event => {
 const checkSmartmatchProp = () => {
 	// Is this code running on a Smartmatch-compatible page?
 	const pageUrl = window.top.location && window.top.location.href;
+	if (!pageUrl) {
+		sendMonitoringEvent('Top window location info inaccessible');
+		return;
+	}
+
 	const isSMpage = pageUrl.match(/ft.com\/content/);
 
 	if (isSMpage) {
 		const hasSMObjOnLoad = Boolean(window.top.smartmatchCreativeMatches);
 		const neg = hasSMObjOnLoad ? ' ' : ' NOT ';
-
-		messenger.post({
-			type: 'oAds.monitor',
-			message: `SM obj was${neg}available when iframe loaded`
-		}, window.top);
+		sendMonitoringEvent(`SM obj was${neg}available when iframe loaded`);
 	}
 };
 


### PR DESCRIPTION
This change makes `o-ads-embed` send a postMessage to the parent window when:

1) an `oAdsEmbed` message has been received by the parent but the parent origin is unexpected
2) on Smartmatch-compatible pages (i.e. article pages) to check the if the expected `smartmatchCreativeMatches` object is available

These changes are likely to be removed once we understand fully what prevents Smartmatch from working as expected. However, the `oAds.monitor` mechanism can be useful in the future if we ensure the consuming app (`o-ads`, `n-ads`) re-sends those events to Spoor.