### PR TITLE
New oAdsEmbed.listens postMessage

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ const checkSmartmatchProp = () => {
 		// Is this code running on a Smartmatch-compatible page?
 		const pageUrl = window.top.location && window.top.location.href;
 		if (!pageUrl) {
-			sendMonitoringEvent('Top window location info inaccessible');
+			sendMonitoringEvent('Top window location empty');
 			return;
 		}
 
@@ -40,10 +40,10 @@ const checkSmartmatchProp = () => {
 		if (isSMpage) {
 			const hasSMObjOnLoad = Boolean(window.top.smartmatchCreativeMatches);
 			const neg = hasSMObjOnLoad ? ' ' : ' NOT ';
-			sendMonitoringEvent(`SM obj was${neg}available when iframe loaded`);
+			sendMonitoringEvent(`SafeFrame seems off & SM obj was${neg}available`);
 		}
 	}	catch(err) {
-		sendMonitoringEvent('Problem accessing window.top.location.href from iframe');
+		sendMonitoringEvent('SafeFrame seems on');
 	}
 
 };
@@ -74,7 +74,6 @@ const oAdsEmbed = {
 				messenger.post({ type: 'oAds.collapse' }, window.top);
 			}
 
-			checkSmartmatchProp();
 		});
 
 		/* istanbul ignore else */
@@ -86,7 +85,9 @@ const oAdsEmbed = {
 	}
 };
 
+checkSmartmatchProp();
 window.addEventListener('message', handleReceivedMessage, false);
+messenger.post({ type: 'oAdsEmbed.listens' }, window.top);
 
 /*
  * swipeHandler


### PR DESCRIPTION
This makes `o-ads-embed` send a new `oAdsEmbed.listens` postMessage to the parent window to indicate that the creative wrapper is, at that point, listening to incoming postMessages.

This intends to improve robustness of communications between the top-level window and the iframe by avoiding a scenario in which the top-level window dispatches a postMessage before the `o-ads-embed` listener has been attached to the DOM which makes the message useless.

This also changes slightly some SmartMatch specific monitoring events. All this monitoring is in place only temporarily for the purpose of gathering data while in the proof-of-concept phase.