### PR TITLE
Added missing app subdomain as accepted origin

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const sendMonitoringEvent = message =>
 const acceptedMessageOrigins = [
 	'https://ft.com',
 	'https://www.ft.com',
+	'https://app.ft.com',
 	'https://www-ft-com.eur.idm.oclc.org',
 	'https://www-ft-com.ezproxy.babson.edu',
 	'https://www-ft-com.baldwinlib.idm.oclc.org',


### PR DESCRIPTION
The app iframes aren't currently receiving the `oAdsEmbed.smartmatchCreativeMatches` because `app.ft.com` isn't allowed as an accepted origin for incoming postMessages. This fixes it.