### PR TITLE
Tab indent the eslint config file.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  "extends": "origami-component",
-  "rules": {
-    "indent": ["error", "tab"]
-  }
+	"extends": "origami-component",
+	"rules": {
+		"indent": ["error", "tab"]
+	}
 };


### PR DESCRIPTION
eslint was recently updated in origami-build-tools, which is likely
to be behind the linting errors now being thrown for the eslint
config file. In this case, I think we're as well to update the
indent than update obt