### PR TITLE
Allow received messages from local.ft.com

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,8 @@ const acceptedMessageOrigins = [
 	'https://ft.com',
 	'https://www.ft.com',
 	'https://app.ft.com',
+	'https://local.ft.com:5050',
+	'https://local.ft.com:8080',
 	'https://www-ft-com.eur.idm.oclc.org',
 	'https://www-ft-com.ezproxy.babson.edu',
 	'https://www-ft-com.baldwinlib.idm.oclc.org',


### PR DESCRIPTION
This PR addresses the issue of messages from a localhost server (both app and Next FT) not being accepted by the o-ads-embed script.