### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import messenger from './src/js/postMessenger';
+import messenger from './src/js/postMessenger.js';
 
 const sendMonitoringEvent = message =>
 	messenger.post({ type: 'oAdsEmbed.monitor', message }, window.top);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from './helpers/fixtures';
-import oAdsEmbed from '../main';
-import { dispatchTouchEvent } from './helpers/utils';
+import * as fixtures from './helpers/fixtures.js';
+import oAdsEmbed from '../main.js';
+import { dispatchTouchEvent } from './helpers/utils.js';
 
 describe('o-ads-embed', () => {
 	context('Window has loaded', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing