### PR TITLE
Remove unnecessary heavy ads monitoring

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,30 +44,6 @@ const checkSafeFrame = () => {
 	}
 };
 
-const monitorHeavyAds = () => {
-	if (!window.ReportingObserver) {
-		return;
-	}
-
-	// create the observer with the callback
-	const observer = new window.ReportingObserver(
-		(reports, observer) => { // eslint-disable-line no-unused-vars
-			console.log('reports', reports); // eslint-disable-line no-console
-		},
-		{ buffered: true }
-	);
-
-	// start watching for interventions
-	observer.observe();
-
-	window.addEventListener('unload', (event) => { // eslint-disable-line no-unused-vars
-
-		// pull all pending reports from the queue
-		const reports = observer.takeRecords();
-		console.log('reports', reports); // eslint-disable-line no-console
-	});
-};
-
 /*
  * Initialise oAds Embed library.
  * - looks for a collapse element in the iframe
@@ -125,7 +101,6 @@ function swipeHandler(event) {
 }
 
 checkSafeFrame();
-monitorHeavyAds();
 window.addEventListener('message', handleReceivedMessage, false);
 
 // Notify the top-level window that the o-ads-embed is listening for


### PR DESCRIPTION
After making that change, I realised that heavy ads intervention events
are triggered in top-level window, which means there is no point in
trying to monitor them in the ads iframes.